### PR TITLE
"&" symbols could interpretted on the server as the start of a new field

### DIFF
--- a/src/components/TrackPageView.js
+++ b/src/components/TrackPageView.js
@@ -17,7 +17,7 @@ class TrackPageViewCore extends Component {
     trackPageView() {
         const {location, match, tracker} = this.props;
 
-        tracker.trackPageView(location, match);
+        tracker.trackPageView({...location, search: encodeURIComponent(location.search)}, match);
     }
 
     render() {


### PR DESCRIPTION
request body will like

![image](https://user-images.githubusercontent.com/6457155/48686932-c0dea180-ebf9-11e8-9730-40355822294b.png)
