### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "types": "./es/index.d.ts",
   "sideEffects": false,
-  "main": "cjs/index.js",
+  "main": "es/index.js",
   "module": "es/index.js",
   "scripts": {
     "lint": "skr lint && tsc",


### PR DESCRIPTION
Since we don't have cjs, point `es/index.js` as main.
jest relies on the field `main`.