### PR TITLE
fix:when set basename with empty string

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,22 @@
+# Node.js with webpack
+# Build a Node.js project using the webpack CLI.
+# Add steps that analyze code, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
+
+trigger:
+- main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '10.x'
+  displayName: 'Install Node.js'
+
+- script: |
+    npm install -g webpack webpack-cli --save-dev
+    npm install
+    npx webpack --config webpack.config.js
+  displayName: 'npm install, run webpack'

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -304,18 +304,35 @@ describe('test hocs', () => {
 });
 
 describe('test basename', () => {
-    test('should return correct pathname & path', () => {
+    const exp = {
+        location: {
+            pathname: '/hi/track/10',
+            path: '/hi/track/:id',
+        },
+    };
+
+    test('should return correct pathname & path when receiving a full basename', () => {
         const collect = basename('/hi');
         const res = collect('pageView', {
             pathname: '/track/10',
             path: '/track/:id',
         });
-        const exp = {
-            location: {
-                pathname: '/hi/track/10',
-                path: '/hi/track/:id',
-            },
-        };
+        expect(res).toEqual(exp);
+    });
+    test('should return correct pathname & path when receiving a basename which starts without /', () => {
+        const collect = basename('hi');
+        const res = collect('pageView', {
+            pathname: '/track/10',
+            path: '/track/:id',
+        });
+        expect(res).toEqual(exp);
+    });
+    test('should return correct pathname & path when receiving a empty string', () => {
+        const collect = basename('');
+        const res = collect('pageView', {
+            pathname: '/hi/track/10',
+            path: '/hi/track/:id',
+        });
         expect(res).toEqual(exp);
     });
 });

--- a/src/collect/basename.ts
+++ b/src/collect/basename.ts
@@ -1,7 +1,8 @@
 import {CollectType, Location, TrackerCollect} from '../types';
 
 export const basename = (name: string): TrackerCollect => {
-    const prefix = name.startsWith('/') ? name : '/' + name;
+    // only process when receiving a non-empty string which starts without /
+    const prefix = /^[^/]/.test(name) ? '/' + name : name;
 
     return (type: CollectType, location?: Location) => {
         if (type !== 'pageView' || !location) {


### PR DESCRIPTION
In current version, when the function "basename" receive a string starting without "/"，it will add a "/" before this string. If the string is empty, which is also a valid input, then function will do the same thing.

Thus, if the prefix is dynamic and it can be an empty string, we have to write in this way: 
```
combineCollects(
    context({}),
    browser(),
    session(),
    (...args) => {
        if (prefix !== '') {
            return basename(prefix)(...args);
        }
        return {};
    },
);
```
Otherwise, the function "basename" will add an useless "/" before empty string, which may cause miscount in statistics.
